### PR TITLE
Fix RunDlg command retrieval tests (Issue #11)

### DIFF
--- a/PowerEditor/src/QtControls/RunDlg/RunDlg.cpp
+++ b/PowerEditor/src/QtControls/RunDlg/RunDlg.cpp
@@ -77,6 +77,7 @@ void RunDlg::setupUI() {
     _commandCombo->setMaxCount(20);
     _commandEdit = _commandCombo->lineEdit();
     _commandEdit->setPlaceholderText(tr("Enter command or select from history..."));
+    _commandEdit->setText(_currentCommand);
     commandLayout->addWidget(_commandCombo, 1);
 
     _browseButton = new QPushButton(tr("..."), dialog);
@@ -147,10 +148,11 @@ QString RunDlg::getCommand() const {
     if (_commandEdit) {
         return _commandEdit->text().trimmed();
     }
-    return QString();
+    return _currentCommand;
 }
 
 void RunDlg::setCommand(const QString& command) {
+    _currentCommand = command;
     if (_commandEdit) {
         _commandEdit->setText(command);
     }


### PR DESCRIPTION
## Summary

Fixes Issue #11 - RunDlg command retrieval test failures.

## Problem

The `RunDlg::getCommand()` and `setCommand()` methods were not working properly when called before the UI was created (i.e., before `doDialog()` was called). This caused 2 test failures in RunDlgTest:
- `testGetCommand()` - returned empty string instead of expected command
- `testSetCommand()` - returned empty string instead of expected command

## Root Cause

The `_commandEdit` QLineEdit is only created in `setupUI()`, which is called from `doDialog()`. The `setCommand()` and `getCommand()` methods checked if `_commandEdit` was null before doing anything, so they silently failed when called before the dialog was shown.

## Solution

1. Store command in `_currentCommand` member variable in `setCommand()` even when `_commandEdit` is not yet initialized
2. Return `_currentCommand` from `getCommand()` when `_commandEdit` is null
3. Initialize `_commandEdit` text with `_currentCommand` in `setupUI()`

This ensures commands can be set and retrieved at any time, regardless of whether the dialog UI has been created.

## Test Results

All 8 RunDlg tests now pass:
```
PASS   : Tests::RunDlgTest::initTestCase()
PASS   : Tests::RunDlgTest::testInit()
PASS   : Tests::RunDlgTest::testDoDialog()
PASS   : Tests::RunDlgTest::testGetCommand()
PASS   : Tests::RunDlgTest::testSetCommand()
PASS   : Tests::RunDlgTest::testGetHistory()
PASS   : Tests::RunDlgTest::testSetHistory()
PASS   : Tests::RunDlgTest::cleanupTestCase()
Totals: 8 passed, 0 failed, 0 skipped, 0 blacklisted, 1ms
```

## Files Changed

- `PowerEditor/src/QtControls/RunDlg/RunDlg.cpp`

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)