### PR TITLE
Linux: Implement system tray icon support (Fixes #12)

### DIFF
--- a/PowerEditor/src/QtControls/MainWindow/Notepad_plus_Window.h
+++ b/PowerEditor/src/QtControls/MainWindow/Notepad_plus_Window.h
@@ -140,6 +140,10 @@ public:
     // Tray icon
     void minimizeToTray();
     void restoreFromTray();
+    void createTrayIconMenu();
+    bool isTrayIconSupported() const;
+    bool shouldMinimizeToTray() const;
+    bool shouldCloseToTray() const;
 
     // Shortcut management
     void refreshShortcuts();
@@ -255,6 +259,8 @@ private slots:
 
     // Tray icon
     void onTrayIconActivated(QSystemTrayIcon::ActivationReason reason);
+    void onTrayIconShowTriggered();
+    void onTrayIconExitTriggered();
 
 private:
     void setupUI();
@@ -334,6 +340,10 @@ private:
 
     // Tray icon
     QSystemTrayIcon* _trayIcon = nullptr;
+    QMenu* _trayIconMenu = nullptr;
+    QAction* _trayIconShowAction = nullptr;
+    QAction* _trayIconExitAction = nullptr;
+    bool _isMinimizedToTray = false;
 
     // Window state
     bool _isFullScreen = false;


### PR DESCRIPTION
## Summary

This PR implements system tray icon support for the Linux Qt6 port of Notepad++ (Issue #12).

## Changes

### New Methods
- `isTrayIconSupported()` - Check if system tray is available using `QSystemTrayIcon::isSystemTrayAvailable()`
- `shouldMinimizeToTray()` - Check if minimize should go to tray based on settings
- `shouldCloseToTray()` - Check if close should go to tray based on settings  
- `createTrayIconMenu()` - Create context menu with Show and Exit actions

### Updated Methods
- `minimizeToTray()` - Now checks for tray support with graceful fallback, creates tray icon with icon and tooltip
- `restoreFromTray()` - Now tracks `_isMinimizedToTray` state properly
- `closeEvent()` - Minimizes to tray instead of closing if enabled in settings
- `changeEvent()` - Minimizes to tray on window minimize if enabled
- `onTrayIconActivated()` - Now handles single click, double click, and context menu

### New Slots
- `onTrayIconShowTriggered()` - Restore window from tray menu
- `onTrayIconExitTriggered()` - Exit application from tray menu

### New Members
- `_trayIconMenu` - Context menu for tray icon
- `_trayIconShowAction` - Show action in context menu
- `_trayIconExitAction` - Exit action in context menu
- `_isMinimizedToTray` - Track if window is minimized to tray

## Features

- **Graceful Fallback**: When tray icon is not supported (e.g., GNOME 3+ without extensions), the window minimizes/closes normally
- **Settings Integration**: Uses existing `NppGUI._isMinimizedToTray` setting from config.xml
- **Context Menu**: Right-click on tray icon shows "Show Notepad++" and "Exit" options
- **Click Handling**: Single or double click restores the window
- **Desktop Environment Support**: Works with KDE Plasma, XFCE, MATE, Cinnamon; requires extension for GNOME 3+

## Testing

Build and test:
```bash
cd build
cmake ../PowerEditor/src -DCMAKE_BUILD_TYPE=Release
make -j$(nproc)
./notepad-plus-plus
```

Enable tray icon in Preferences > MISC and test minimize/close behavior.

## Checklist

- [x] Added tray icon support detection
- [x] Implemented minimize to tray functionality
- [x] Implemented close to tray functionality
- [x] Added context menu with Show/Exit options
- [x] Handles single/double click to restore
- [x] Graceful fallback for unsupported environments
- [x] Respects existing settings from config.xml
- [x] Build passes successfully

Fixes #12