### PR TITLE
Linux: Fix file tab close button not working (Issue #19)

### DIFF
--- a/PowerEditor/src/QtControls/MainWindow/Notepad_plus_Window.h
+++ b/PowerEditor/src/QtControls/MainWindow/Notepad_plus_Window.h
@@ -43,6 +43,9 @@
 // Forward declaration
 class Notepad_plus;
 class ScintillaEditView;
+namespace QtControls {
+class DocTabView;
+}
 
 // Forward declarations for dialogs
 namespace QtControls {
@@ -253,6 +256,8 @@ private slots:
     // Tab bar
     void onTabChanged(int index);
     void onTabCloseRequested(int index);
+    void onMainTabCloseRequested(int index);
+    void onSubTabCloseRequested(int index);
 
     // Panel visibility
     void onPanelVisibilityChanged(bool visible);
@@ -305,6 +310,10 @@ private:
     // Tab bar
     TabBar* _tabBar = nullptr;
     QTabWidget* _tabWidget = nullptr;
+
+    // DocTabViews (for signal connections)
+    DocTabView* _mainDocTab = nullptr;
+    DocTabView* _subDocTab = nullptr;
 
     // Menus
     QMenuBar* _menuBar = nullptr;


### PR DESCRIPTION
## Summary
Fixes GitHub Issue #19: File tab doesn't allow the closure of files.

## Problem
When clicking the X on a file tab to close it, nothing happened. Files would not close via the tab close button.

## Root Cause
The `tabCloseRequested` signal from `DocTabView` (which inherits from `TabBarPlus`) was not connected to any slot in `MainWindow`. The `connectSignals()` function was empty with only a placeholder comment.

## Solution
1. Added forward declaration for `DocTabView` in MainWindow header
2. Added `_mainDocTab` and `_subDocTab` member pointers to store DocTabView instances for signal connection
3. Modified `setupUI()` to store DocTabView pointers in member variables
4. Implemented `connectSignals()` to connect `tabCloseRequested` signals from both main and sub DocTabView to new handler slots
5. Added `onMainTabCloseRequested()` and `onSubTabCloseRequested()` slots that properly call `_pNotepad_plus->fileClose()` with the correct buffer ID and view identifier (MAIN_VIEW or SUB_VIEW)

## Testing
- Built successfully on Linux with Qt6
- Application starts and runs correctly
- The fix ensures that when a user clicks the X on a tab, the file is properly closed through the Notepad_plus core, which handles:
  - Unsaved changes (prompts for save)
  - Cloned buffers (buffers open in multiple views)
  - All other edge cases handled by the existing fileClose() implementation

## Files Changed
- `PowerEditor/src/QtControls/MainWindow/Notepad_plus_Window.h`
- `PowerEditor/src/QtControls/MainWindow/Notepad_plus_Window.cpp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)